### PR TITLE
avoid conflict with the Logger in Ruby stdlib

### DIFF
--- a/lib/red_storm/proxy/bolt.rb
+++ b/lib/red_storm/proxy/bolt.rb
@@ -9,8 +9,6 @@ java_import 'backtype.storm.tuple.Fields'
 java_import 'backtype.storm.tuple.Values'
 java_import 'java.util.Map'
 
-java_import 'org.apache.log4j.Logger'
-
 java_package 'redstorm.proxy'
 
 # the Bolt class is a proxy to the real bolt to avoid having to deal with all the

--- a/lib/red_storm/proxy/spout.rb
+++ b/lib/red_storm/proxy/spout.rb
@@ -9,8 +9,6 @@ java_import 'backtype.storm.tuple.Fields'
 java_import 'backtype.storm.tuple.Values'
 java_import 'java.util.Map'
 
-java_import 'org.apache.log4j.Logger'
-
 java_package 'redstorm.proxy'
 
 # the Spout class is a proxy to the real spout to avoid having to deal with all the

--- a/lib/red_storm/simple_topology.rb
+++ b/lib/red_storm/simple_topology.rb
@@ -77,7 +77,7 @@ module RedStorm
     end
 
     def self.log
-      @log ||= Logger.getLogger(self.name)
+      @log ||= org.apache.log4j.Logger.getLogger(self.name)
     end
 
 

--- a/lib/red_storm/topology_launcher.rb
+++ b/lib/red_storm/topology_launcher.rb
@@ -21,8 +21,6 @@ java_import 'backtype.storm.tuple.Values'
 java_import 'redstorm.storm.jruby.JRubyBolt'
 java_import 'redstorm.storm.jruby.JRubySpout'
 
-java_import 'org.apache.log4j.Logger'
-
 java_package 'redstorm'
 
 # TopologyLauncher is the application entry point when launching a topology. Basically it will 


### PR DESCRIPTION
remove java_import of org.apache.log4j.Logger to avoid conflict with the Logger in Ruby stdlib which will cause (TypeError) no public constructors for Java::OrgApacheLog4j::Logger
