### PR TITLE
Fixed real cause of issue #7

### DIFF
--- a/lib/red_storm/simple_topology.rb
+++ b/lib/red_storm/simple_topology.rb
@@ -61,7 +61,7 @@ module RedStorm
       attr_reader :config
 
       def initialize
-        @config = Config.new
+        @config = Backtype::Config.new
       end
 
       def method_missing(sym, *args)

--- a/lib/red_storm/topology_launcher.rb
+++ b/lib/red_storm/topology_launcher.rb
@@ -10,7 +10,11 @@ rescue LoadError
   require 'red_storm'
 end
 
-java_import 'backtype.storm.Config'
+# see https://github.com/colinsurprenant/redstorm/issues/7
+module Backtype
+  java_import 'backtype.storm.Config'
+end
+
 java_import 'backtype.storm.LocalCluster'
 java_import 'backtype.storm.StormSubmitter'
 java_import 'backtype.storm.topology.TopologyBuilder'


### PR DESCRIPTION
I've read the discussion of #7, but was facing the same issue without the circumstances of the original poster.
After some investigation looks like it is related to type redefinition made by java_import.

Look like java_import was introducing a class overwrite for 'Config',
and when `rbconfig` needed to be used (Config::CONFIG), the error would surface.

rbconfig is used with rack utils, and you can verify by installing any gem which uses rack, and trying to require it within a spout or bolt.

thanks.
