### PR TITLE
Log4j Logger class conflict

### DIFF
--- a/lib/red_storm/proxy/bolt.rb
+++ b/lib/red_storm/proxy/bolt.rb
@@ -8,7 +8,6 @@ java_import 'backtype.storm.tuple.Tuple'
 java_import 'backtype.storm.tuple.Fields'
 java_import 'backtype.storm.tuple.Values'
 java_import 'java.util.Map'
-java_import 'org.apache.log4j.Logger'
 module Backtype
   java_import 'backtype.storm.Config'
 end

--- a/lib/red_storm/proxy/spout.rb
+++ b/lib/red_storm/proxy/spout.rb
@@ -8,7 +8,6 @@ java_import 'backtype.storm.tuple.Tuple'
 java_import 'backtype.storm.tuple.Fields'
 java_import 'backtype.storm.tuple.Values'
 java_import 'java.util.Map'
-java_import 'org.apache.log4j.Logger'
 module Backtype
   java_import 'backtype.storm.Config'
 end


### PR DESCRIPTION
`no public constructors for Java::OrgApacheLog4j::Logger`
