### PR TITLE
Fix native examples (missing argument for proxy constructors)

### DIFF
--- a/examples/native/cluster_word_count_topology.rb
+++ b/examples/native/cluster_word_count_topology.rb
@@ -10,9 +10,9 @@ module RedStorm
 
       def start(base_class_path, env)
         builder = TopologyBuilder.new
-        builder.setSpout('RandomSentenceSpout', JRubySpout.new(base_class_path, "RedStorm::Examples::RandomSentenceSpout"), 5)
-        builder.setBolt('SplitSentenceBolt', JRubyBolt.new(base_class_path, "RedStorm::Examples::SplitSentenceBolt"), 4).shuffleGrouping('RandomSentenceSpout')
-        builder.setBolt('WordCountBolt', JRubyBolt.new(base_class_path, "RedStorm::Examples::WordCountBolt"), 4).fieldsGrouping('SplitSentenceBolt', Fields.new("word"))
+        builder.setSpout('RandomSentenceSpout', JRubySpout.new(base_class_path, "RedStorm::Examples::RandomSentenceSpout", []), 5)
+        builder.setBolt('SplitSentenceBolt', JRubyBolt.new(base_class_path, "RedStorm::Examples::SplitSentenceBolt", []), 4).shuffleGrouping('RandomSentenceSpout')
+        builder.setBolt('WordCountBolt', JRubyBolt.new(base_class_path, "RedStorm::Examples::WordCountBolt", []), 4).fieldsGrouping('SplitSentenceBolt', Fields.new("word"))
 
         conf = Backtype::Config.new
         conf.setDebug(true)

--- a/examples/native/local_exclamation_topology.rb
+++ b/examples/native/local_exclamation_topology.rb
@@ -12,14 +12,14 @@ module RedStorm
 
       def start(base_class_path, env)
         builder = TopologyBuilder.new
-        
-        builder.setSpout('TestWordSpout', TestWordSpout.new, 10)     
-        builder.setBolt('ExclamationBolt1', JRubyBolt.new(base_class_path, 'RedStorm::Examples::ExclamationBolt'), 3).shuffleGrouping('TestWordSpout')
-        builder.setBolt('ExclamationBolt2', JRubyBolt.new(base_class_path, 'RedStorm::Examples::ExclamationBolt'), 3).shuffleGrouping('ExclamationBolt1')
-                
+
+        builder.setSpout('TestWordSpout', TestWordSpout.new, 10)
+        builder.setBolt('ExclamationBolt1', JRubyBolt.new(base_class_path, 'RedStorm::Examples::ExclamationBolt', []), 3).shuffleGrouping('TestWordSpout')
+        builder.setBolt('ExclamationBolt2', JRubyBolt.new(base_class_path, 'RedStorm::Examples::ExclamationBolt', []), 3).shuffleGrouping('ExclamationBolt1')
+
         conf = Backtype::Config.new
         conf.setDebug(true)
-        
+
         cluster = LocalCluster.new
         cluster.submitTopology("exclamation", conf, builder.createTopology)
         sleep(5)

--- a/examples/native/local_exclamation_topology2.rb
+++ b/examples/native/local_exclamation_topology2.rb
@@ -29,14 +29,14 @@ module RedStorm
 
       def start(base_class_path, env)
         builder = TopologyBuilder.new
-        
-        builder.setSpout('TestWordSpout', TestWordSpout.new, 10)     
-        builder.setBolt('ExclamationBolt21', JRubyBolt.new(base_class_path, "RedStorm::Examples::ExclamationBolt2"), 3).shuffleGrouping('TestWordSpout')
-        builder.setBolt('ExclamationBolt22', JRubyBolt.new(base_class_path, "RedStorm::Examples::ExclamationBolt2"), 2).shuffleGrouping('ExclamationBolt21')
-                
+
+        builder.setSpout('TestWordSpout', TestWordSpout.new, 10)
+        builder.setBolt('ExclamationBolt21', JRubyBolt.new(base_class_path, "RedStorm::Examples::ExclamationBolt2", []), 3).shuffleGrouping('TestWordSpout')
+        builder.setBolt('ExclamationBolt22', JRubyBolt.new(base_class_path, "RedStorm::Examples::ExclamationBolt2", []), 2).shuffleGrouping('ExclamationBolt21')
+
         conf = Backtype::Config.new
         conf.setDebug(true)
-        
+
         cluster = LocalCluster.new
         cluster.submitTopology("exclamation", conf, builder.createTopology)
         sleep(5)

--- a/examples/native/local_redis_word_count_topology.rb
+++ b/examples/native/local_redis_word_count_topology.rb
@@ -6,7 +6,7 @@ require 'examples/native/word_count_bolt'
 
 module RedStorm
   module Examples
-    # RedisWordSpout reads the Redis queue "test" on localhost:6379 
+    # RedisWordSpout reads the Redis queue "test" on localhost:6379
     # and emits each word items pop'ed from the queue.
     class RedisWordSpout
       def open(conf, context, collector)
@@ -14,7 +14,7 @@ module RedStorm
         @q = Queue.new
         @redis_reader = detach_redis_reader
       end
-      
+
       def next_tuple
         # per doc nextTuple should not block, and sleep a bit when there's no data to process.
         if @q.size > 0
@@ -52,8 +52,8 @@ module RedStorm
 
       def start(base_class_path, env)
         builder = TopologyBuilder.new
-        builder.setSpout('RedisWordSpout', JRubySpout.new(base_class_path, "RedStorm::Examples::RedisWordSpout"), 1)
-        builder.setBolt('WordCountBolt', JRubyBolt.new(base_class_path, "RedStorm::Examples::WordCountBolt"), 3).fieldsGrouping('RedisWordSpout', Fields.new("word"))
+        builder.setSpout('RedisWordSpout', JRubySpout.new(base_class_path, "RedStorm::Examples::RedisWordSpout", []), 1)
+        builder.setBolt('WordCountBolt', JRubyBolt.new(base_class_path, "RedStorm::Examples::WordCountBolt", []), 3).fieldsGrouping('RedisWordSpout', Fields.new("word"))
 
         conf = Backtype::Config.new
         conf.setDebug(true)

--- a/examples/native/local_word_count_topology.rb
+++ b/examples/native/local_word_count_topology.rb
@@ -10,9 +10,9 @@ module Examples
 
     def start(base_class_path, env)
       builder = TopologyBuilder.new
-      builder.setSpout('RandomSentenceSpout', JRubySpout.new(base_class_path, "RedStorm::Examples::RandomSentenceSpout"), 5)
-      builder.setBolt('SplitSentenceBolt', JRubyBolt.new(base_class_path, "RedStorm::Examples::SplitSentenceBolt"), 8).shuffleGrouping('RandomSentenceSpout')
-      builder.setBolt('WordCountBolt', JRubyBolt.new(base_class_path, "RedStorm::Examples::WordCountBolt"), 12).fieldsGrouping('SplitSentenceBolt', Fields.new("word"))
+      builder.setSpout('RandomSentenceSpout', JRubySpout.new(base_class_path, "RedStorm::Examples::RandomSentenceSpout", []), 5)
+      builder.setBolt('SplitSentenceBolt', JRubyBolt.new(base_class_path, "RedStorm::Examples::SplitSentenceBolt", []), 8).shuffleGrouping('RandomSentenceSpout')
+      builder.setBolt('WordCountBolt', JRubyBolt.new(base_class_path, "RedStorm::Examples::WordCountBolt", []), 12).fieldsGrouping('SplitSentenceBolt', Fields.new("word"))
 
       conf = Backtype::Config.new
       conf.setDebug(true)


### PR DESCRIPTION
Fix native examples that were broken by df9795a9ac.
(I'd rather have varargs or overloaded constructors in JRubyBolt & JRubySpout, but they don't bind directly to JRuby)
