### PR TITLE
Add (fixed) versions of JRubyShellBolt and JRubyShellSpout.

### DIFF
--- a/src/main/redstorm/storm/jruby/JRubyShellBolt.java
+++ b/src/main/redstorm/storm/jruby/JRubyShellBolt.java
@@ -1,0 +1,26 @@
+package redstorm.storm.jruby;
+
+import backtype.storm.task.ShellBolt;
+import backtype.storm.topology.IRichBolt;
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.tuple.Fields;
+import java.util.Map;
+    
+public class JRubyShellBolt  extends ShellBolt  implements IRichBolt {
+  private String[] _fields;
+
+  public JRubyShellBolt(String[] command, String[] fields) {
+    super(command);
+    _fields = fields;
+  }
+
+  @Override
+  public void declareOutputFields(OutputFieldsDeclarer declarer) {
+    declarer.declare(new Fields(_fields));
+  }
+
+  @Override
+  public Map<String, Object> getComponentConfiguration() {
+    return null;
+  }
+}

--- a/src/main/redstorm/storm/jruby/JRubyShellSpout.java
+++ b/src/main/redstorm/storm/jruby/JRubyShellSpout.java
@@ -1,0 +1,26 @@
+package redstorm.storm.jruby;
+
+import backtype.storm.spout.ShellSpout;
+import backtype.storm.topology.IRichSpout;
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.tuple.Fields;
+import java.util.Map;
+
+public class JRubyShellSpout extends ShellSpout implements IRichSpout {
+  private String[] _fields;
+
+  public JRubyShellSpout(String[] command, String[] fields) {
+    super(command);
+    _fields = fields;
+  }
+
+  @Override
+  public void declareOutputFields(OutputFieldsDeclarer declarer) {
+    declarer.declare(new Fields(_fields));
+  }
+
+  @Override
+  public Map<String, Object> getComponentConfiguration() {
+    return null;
+  }
+}


### PR DESCRIPTION
I don't know why these aren't in the repo (they're in the gem), but add them, and fix the package for JRubyShellSpout.
