### PR TITLE
ant rake task error message fix

### DIFF
--- a/lib/tasks/red_storm.rake
+++ b/lib/tasks/red_storm.rake
@@ -1,7 +1,8 @@
 begin
   require 'ant'
 rescue
-  puts("error: unable to load Ant, make sure Ant is installed and in your PATH")
+  puts("error: unable to load Ant, make sure Ant is installed, in your PATH")
+  puts("       and $ANT_HOME is defined properly.")
   puts("\nerror detail:\n#{$!}")
   exit(1)
 end


### PR DESCRIPTION
Very slight tweak to the error message mentioning ANT_HOME must be defined.

I was in a situation where ant was in my path but doing a redstorm install bailed complaining ant wasn't in my path. My problem was not having defined ANT_HOME.
