### PR TITLE
Remind people to update the java deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ The jars repositories can be configured by adding the `ivy/settings.xml` file in
   </ivysettings>
   ```
 
+### Update the java dependencies if you've changed them
+
+``` sh
+$ redstorm dep
+``` 
+
 ### Run in local mode
 
 ``` sh


### PR DESCRIPTION
seems a small oversight was made in documenting the way to update things when using ivy
