### PR TITLE
OutputCollector  alias bug

### DIFF
--- a/lib/red_storm/dsl/output_collector.rb
+++ b/lib/red_storm/dsl/output_collector.rb
@@ -1,8 +1,9 @@
 require 'java'
 java_import 'backtype.storm.task.OutputCollector'
+java_import 'backtype.storm.tuple.Tuple'
 
 # make alias methods to specific signatures to avoid selection overhead for heavily overloaded method
 class OutputCollector
   java_alias :emit_tuple, :emit, [java.lang.Class.for_name("java.util.List")]
-  java_alias :emit_anchor_tuple, :emit, [java.lang.Class.for_name("backtype.storm.tuple.Tuple"), java.lang.Class.for_name("java.util.List")]
+  java_alias :emit_anchor_tuple, :emit, [Tuple.java_class, java.lang.Class.for_name("java.util.List")]
 end

--- a/lib/red_storm/dsl/topology.rb
+++ b/lib/red_storm/dsl/topology.rb
@@ -3,6 +3,7 @@ require 'red_storm/configuration'
 require 'red_storm/configurator'
 
 java_import 'backtype.storm.topology.TopologyBuilder'
+java_import 'backtype.storm.generated.SubmitOptions'
 
 module RedStorm
   module DSL
@@ -135,6 +136,10 @@ module RedStorm
         @configure_block = configure_block if block_given?
       end
 
+      def self.submit_options(&submit_options_block)
+        @submit_options_block = submit_options_block if block_given?
+      end
+
       def self.on_submit(method_name = nil, &submit_block)
         @submit_block = block_given? ? submit_block : lambda {|env| self.send(method_name, env)}
       end
@@ -165,7 +170,16 @@ module RedStorm
         configurator.instance_exec(env, &self.class.configure_block)
 
         submitter = (env == :local) ? @cluster = LocalCluster.new : StormSubmitter
-        submitter.submitTopology(self.class.topology_name, configurator.config, topology)
+
+        if self.class.submit_options_block
+          submit_options = SubmitOptions.new
+          submit_options.instance_exec(env, &self.class.submit_options_block)
+
+          submitter.submitTopology(self.class.topology_name, configurator.config, topology, submit_options)
+        else
+          submitter.submitTopology(self.class.topology_name, configurator.config, topology)
+        end
+
         instance_exec(env, &self.class.submit_block)
       end
 
@@ -209,6 +223,10 @@ module RedStorm
 
       def self.configure_block
         @configure_block ||= lambda{|env|}
+      end
+
+      def self.submit_options_block
+        @submit_options_block
       end
 
       def self.submit_block

--- a/lib/red_storm/version.rb
+++ b/lib/red_storm/version.rb
@@ -1,3 +1,3 @@
 module RedStorm
-  VERSION = '0.7.0.beta1'
+  VERSION = '0.7.0.beta1.lookout1'
 end


### PR DESCRIPTION
```
LoadError: load error: red_storm/dsl/output_collector -- java.lang.ClassNotFoundException: backtype/storm/tuple/Tuple
```

I'm not sure why this occurs, but the output_collector alias of :emit_anchor_tuple keeps redstorm from loading for me; with the below change, it runs fine.  (I have not been able to run redstorm's own spec tests due to some bundler problems, but this is reproducable in pry by loading the jars and classes, then `require 'red_storm'.)
