### PR TITLE
OutputCollector patch

### DIFF
--- a/lib/red_storm/dsl/output_collector.rb
+++ b/lib/red_storm/dsl/output_collector.rb
@@ -1,8 +1,9 @@
 require 'java'
 java_import 'backtype.storm.task.OutputCollector'
+java_import 'backtype.storm.tuple.Tuple'
 
 # make alias methods to specific signatures to avoid selection overhead for heavily overloaded method
 class OutputCollector
   java_alias :emit_tuple, :emit, [java.lang.Class.for_name("java.util.List")]
-  java_alias :emit_anchor_tuple, :emit, [java.lang.Class.for_name("backtype.storm.tuple.Tuple"), java.lang.Class.for_name("java.util.List")]
+  java_alias :emit_anchor_tuple, :emit, [Tuple.java_class, java.lang.Class.for_name("java.util.List")]
 end

--- a/spec/red_storm/dsl/output_collector_spec.rb
+++ b/spec/red_storm/dsl/output_collector_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+require 'red_storm/dsl/output_collector'
+
+describe OutputCollector do
+  describe '#instance methods' do
+    subject { described_class.new('foo') }
+
+    # We should have an alias for #emit_tuple
+    it { should respond_to :emit_tuple }
+
+    # We should have an alias for #emit_anchor_tuple
+    it { should respond_to :emit_anchor_tuple }
+  end
+end


### PR DESCRIPTION
Without this patch, I get the following error: `LoadError: load error: red_storm/dsl/output_collector -- java.lang.ClassNotFoundException: backtype/storm/tuple/Tuple`

Note: this is the same issue as #95, just reopened now that this repo has been moved.  I also added a test; the spec below does repro the bug for me in  JRuby 1.7.12 if the change to `lib/red_storm/dsl/output_collector.rb` is not present.
