### PR TITLE
rescue DEFAULT_STORM_CONF_FILE so we can use redstorm in envs with no HOME

### DIFF
--- a/lib/red_storm/environment.rb
+++ b/lib/red_storm/environment.rb
@@ -47,7 +47,7 @@ module RedStorm
   DEFAULT_IVY_TOPOLOGY_DEPENDENCIES = "#{SRC_IVY_DIR}/topology_dependencies.xml"
   CUSTOM_IVY_TOPOLOGY_DEPENDENCIES = "#{DST_IVY_DIR}/topology_dependencies.xml"
 
-  DEFAULT_STORM_CONF_FILE = File.expand_path("~/.storm/storm.yaml")
+  DEFAULT_STORM_CONF_FILE = File.expand_path("~/.storm/storm.yaml") rescue ''
 
   def current_ruby_mode
     version = RUBY_VERSION[/(\d+\.\d+)(\.\d+)*/, 1]


### PR DESCRIPTION
If our local environment doesn't have a HOME, we might still specify conf file via `-Dstorm.conf.file=foo`; but the default still requires that ENV['HOME'] exist.  This patch rescues the resulting error so we don't depend on ENV['HOME'].
