### PR TITLE
Add DSL support for declaring named streams for Bolts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.0)
     colorize (0.5.8)
     coveralls (0.6.7)
       colorize
@@ -15,8 +16,15 @@ GEM
       simplecov (>= 0.7)
       thor
     diff-lcs (1.2.4)
+    ffi (1.9.8-java)
+    method_source (0.8.2)
     mime-types (1.23)
     multi_json (1.7.7)
+    pry (0.10.1-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+      spoon (~> 0.0)
     rake (10.0.4)
     redis (3.0.4)
     rest-client (1.6.7)
@@ -33,6 +41,9 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
     simplecov-html (0.7.1)
+    slop (3.6.0)
+    spoon (0.0.4)
+      ffi
     thor (0.18.1)
 
 PLATFORMS
@@ -40,6 +51,7 @@ PLATFORMS
 
 DEPENDENCIES
   coveralls
+  pry
   redis
   redstorm!
   rspec (~> 2.13)

--- a/lib/red_storm/dsl/bolt.rb
+++ b/lib/red_storm/dsl/bolt.rb
@@ -26,7 +26,9 @@ module RedStorm
         @fields ||= []
         fields.each do |field|
           if field.kind_of? Hash
-            @fields << Hash[ field.map { |k, v| [k.to_s, v.to_s] } ]
+            @fields << Hash[
+              field.map { |k, v| [k.to_s, v.kind_of?(Array) ? v.map(&:to_s) : v.to_s] }
+            ]
           else
             @fields << field.to_s
           end
@@ -142,7 +144,7 @@ module RedStorm
           end
         end
 
-        declarer.declare(Fields.new(default_fields.flatten))
+        declarer.declare(Fields.new(default_fields.flatten)) unless default_fields.empty?
       end
 
       def get_component_configuration

--- a/lib/red_storm/dsl/output_collector.rb
+++ b/lib/red_storm/dsl/output_collector.rb
@@ -6,4 +6,13 @@ java_import 'backtype.storm.tuple.Tuple'
 class OutputCollector
   java_alias :emit_tuple, :emit, [java.lang.Class.for_name("java.util.List")]
   java_alias :emit_anchor_tuple, :emit, [Tuple.java_class, java.lang.Class.for_name("java.util.List")]
+  java_alias :emit_tuple_stream, :emit, [
+    java.lang.String,
+    java.lang.Class.for_name("java.util.List")
+  ]
+  java_alias :emit_anchor_tuple_stream, :emit, [
+    java.lang.String,
+    Tuple.java_class,
+    java.lang.Class.for_name("java.util.List")
+  ]
 end

--- a/lib/red_storm/dsl/output_fields.rb
+++ b/lib/red_storm/dsl/output_fields.rb
@@ -1,0 +1,58 @@
+
+module RedStorm
+  module DSL
+    module OutputFields
+
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      def declare_output_fields(declarer)
+        default_fields = []
+        self.class.fields.each do |field|
+          if field.kind_of? Hash
+            field.each do |stream, fields|
+              declarer.declareStream(stream, Fields.new(fields))
+            end
+          else
+            default_fields << field
+          end
+        end
+
+        declarer.declare(Fields.new(default_fields.flatten)) unless default_fields.empty?
+      end
+
+      def stream
+        self.class.stream
+      end
+
+      module ClassMethods
+        def output_fields(*fields)
+          @fields ||= []
+          fields.each do |field|
+            if field.kind_of? Hash
+              @fields << Hash[
+                field.map { |k, v| [k.to_s, v.kind_of?(Array) ? v.map(&:to_s) : v.to_s] }
+              ]
+            else
+              @fields << field.to_s
+            end
+          end
+        end
+
+        def fields
+          @fields ||= []
+        end
+
+        def stream?
+          self.receive_options[:stream] && !self.receive_options[:stream].empty?
+        end
+
+        def stream
+          self.receive_options[:stream]
+        end
+      end
+    end
+  end
+end
+

--- a/lib/red_storm/dsl/output_fields.rb
+++ b/lib/red_storm/dsl/output_fields.rb
@@ -1,4 +1,3 @@
-
 module RedStorm
   module DSL
     module OutputFields
@@ -8,18 +7,9 @@ module RedStorm
       end
 
       def declare_output_fields(declarer)
-        default_fields = []
-        self.class.fields.each do |field|
-          if field.kind_of? Hash
-            field.each do |stream, fields|
-              declarer.declareStream(stream, Fields.new(fields))
-            end
-          else
-            default_fields << field
-          end
+        self.class.fields.each do |stream, fields|
+          declarer.declareStream(stream, Fields.new(fields))
         end
-
-        declarer.declare(Fields.new(default_fields.flatten)) unless default_fields.empty?
       end
 
       def stream
@@ -27,21 +17,21 @@ module RedStorm
       end
 
       module ClassMethods
+
         def output_fields(*fields)
-          @fields ||= []
+          @output_fields ||= Hash.new([])
           fields.each do |field|
-            if field.kind_of? Hash
-              @fields << Hash[
-                field.map { |k, v| [k.to_s, v.kind_of?(Array) ? v.map(&:to_s) : v.to_s] }
-              ]
+            case field
+            when Hash
+              field.each { |k, v| @output_fields[k.to_s] = v.kind_of?(Array) ? v.map(&:to_s) : [v.to_s] }
             else
-              @fields << field.to_s
+              @output_fields['default'] |= field.kind_of?(Array) ? field.map(&:to_s) : [field.to_s]
             end
           end
         end
 
         def fields
-          @fields ||= []
+          @output_fields ||= Hash.new([])
         end
 
         def stream?

--- a/lib/red_storm/dsl/spout.rb
+++ b/lib/red_storm/dsl/spout.rb
@@ -1,6 +1,7 @@
 require 'java'
 require 'red_storm/configurator'
 require 'red_storm/environment'
+require 'red_storm/dsl/output_fields'
 require 'pathname'
 
 module RedStorm
@@ -10,6 +11,8 @@ module RedStorm
 
     class Spout
       attr_reader :config, :context, :collector
+
+      include OutputFields
 
       def self.java_proxy; "Java::RedstormStormJruby::JRubySpout"; end
 
@@ -21,10 +24,6 @@ module RedStorm
 
       def self.log
         @log ||= Java::OrgApacheLog4j::Logger.getLogger(self.name)
-      end
-
-      def self.output_fields(*fields)
-        @fields = fields.map(&:to_s)
       end
 
       def self.on_send(*args, &on_send_block)
@@ -126,10 +125,6 @@ module RedStorm
         on_deactivate
       end
 
-      def declare_output_fields(declarer)
-        declarer.declare(Fields.new(self.class.fields))
-      end
-
       def ack(msg_id)
         on_ack(msg_id)
       end
@@ -153,10 +148,6 @@ module RedStorm
       def on_deactivate; end
       def on_ack(msg_id); end
       def on_fail(msg_id); end
-
-      def self.fields
-        @fields ||= []
-      end
 
       def self.configure_block
         @configure_block ||= lambda {}

--- a/lib/red_storm/dsl/topology.rb
+++ b/lib/red_storm/dsl/topology.rb
@@ -60,29 +60,33 @@ module RedStorm
           @sources = []
         end
 
-        def source(source_id, grouping)
-          @sources << [source_id.is_a?(Class) ? Topology.underscore(source_id) : source_id.to_s, grouping.is_a?(Hash) ? grouping : {grouping => nil}]
+        def source(source_id, grouping, stream = 'default')
+          @sources << [
+            source_id.is_a?(Class) ? Topology.underscore(source_id) : source_id.to_s,
+            grouping.is_a?(Hash) ? grouping : {grouping => nil},
+            stream.to_s
+          ]
         end
 
         def define_grouping(declarer)
-          @sources.each do |source_id, grouping|
+          @sources.each do |source_id, grouping, stream|
             grouper, params = grouping.first
               # declarer.fieldsGrouping(source_id, Fields.new())
             case grouper
             when :fields
-              declarer.fieldsGrouping(source_id, Fields.new(*([params].flatten.map(&:to_s))))
+              declarer.fieldsGrouping(source_id, stream, Fields.new(*([params].flatten.map(&:to_s))))
             when :global
-              declarer.globalGrouping(source_id)
+              declarer.globalGrouping(source_id, stream)
             when :shuffle
-              declarer.shuffleGrouping(source_id)
+              declarer.shuffleGrouping(source_id, stream)
             when :local_or_shuffle
-              declarer.localOrShuffleGrouping(source_id)
+              declarer.localOrShuffleGrouping(source_id, stream)
             when :none
-              declarer.noneGrouping(source_id)
+              declarer.noneGrouping(source_id, stream)
             when :all
-              declarer.allGrouping(source_id)
+              declarer.allGrouping(source_id, stream)
             when :direct
-              declarer.directGrouping(source_id)
+              declarer.directGrouping(source_id, stream)
             else
               raise("unknown grouper=#{grouper.inspect}")
             end

--- a/redstorm.gemspec
+++ b/redstorm.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |s|
   s.executables   = ['redstorm']
 
   s.add_development_dependency 'rspec', '~> 2.13'
+  s.add_development_dependency 'pry'
   s.add_runtime_dependency 'rake'
 end

--- a/spec/red_storm/dsl/bolt_spec.rb
+++ b/spec/red_storm/dsl/bolt_spec.rb
@@ -45,42 +45,42 @@ describe RedStorm::SimpleBolt do
           output_fields :f1
         end
         bolt = Bolt1.new
-        Bolt1.send(:fields).should == ["f1"]
+        Bolt1.send(:fields).should == {"default" => ["f1"]}
       end
 
       it "should parse multiple arguments" do
         class Bolt1 < RedStorm::SimpleBolt
           output_fields :f1, :f2
         end
-        Bolt1.send(:fields).should == ["f1", "f2"]
+        Bolt1.send(:fields).should == {"default" => ["f1", "f2"]}
       end
 
       it "should parse string and symbol arguments" do
         class Bolt1 < RedStorm::SimpleBolt
           output_fields :f1, "f2"
         end
-        Bolt1.send(:fields).should == ["f1", "f2"]
+        Bolt1.send(:fields).should == {"default" => ["f1", "f2"]}
       end
 
       it "should parse single hash argument" do
         class Bolt1 < RedStorm::SimpleBolt
           output_fields :stream => :f1
         end
-        Bolt1.send(:fields).should == [{"stream" => "f1"}]
+        Bolt1.send(:fields).should == {"stream" => ["f1"]}
       end
 
       it "should parse hash of string and symbols" do
         class Bolt1 < RedStorm::SimpleBolt
           output_fields "stream" => [:f1, :f2]
         end
-        Bolt1.send(:fields).should == [{"stream" => ["f1", "f2"]}]
+        Bolt1.send(:fields).should == {"stream" => ["f1", "f2"]}
       end
 
       it "should parse string and hash arguments" do
         class Bolt1 < RedStorm::SimpleBolt
           output_fields :f1, :stream => :f2
         end
-        Bolt1.send(:fields).should == ["f1", {"stream" => "f2"}]
+        Bolt1.send(:fields).should == {"default" => ["f1"], "stream" => ["f2"]}
       end
 
       it "should not share state over mutiple classes" do
@@ -90,9 +90,9 @@ describe RedStorm::SimpleBolt do
         class Bolt2 < RedStorm::SimpleBolt
           output_fields :f2
         end
-        RedStorm::SimpleBolt.send(:fields).should == []
-        Bolt1.send(:fields).should == ["f1"]
-        Bolt2.send(:fields).should == ["f2"]
+        RedStorm::SimpleBolt.send(:fields).should == {}
+        Bolt1.send(:fields).should == {"default" => ["f1"]}
+        Bolt2.send(:fields).should == {"default" => ["f2"]}
       end
     end
 
@@ -804,7 +804,7 @@ describe RedStorm::SimpleBolt do
         bolt = Bolt1.new
         class RedStorm::Fields; end
         declarer = mock("Declarer")
-        declarer.should_receive(:declare).with("fields")
+        declarer.should_receive(:declareStream).with("default", "fields")
         RedStorm::Fields.should_receive(:new).with(["f1", "f2"]).and_return("fields")
         bolt.declare_output_fields(declarer)
       end
@@ -829,7 +829,7 @@ describe RedStorm::SimpleBolt do
         class RedStorm::Fields; end
         declarer = mock("Declarer")
         declarer.should_receive(:declareStream).with("stream", "stream_fields")
-        declarer.should_receive(:declare).with("default_fields")
+        declarer.should_receive(:declareStream).with("default", "default_fields")
         RedStorm::Fields.should_receive(:new).with(["f3", "f4"]).and_return("stream_fields")
         RedStorm::Fields.should_receive(:new).with(["f1", "f2"]).and_return("default_fields")
         bolt.declare_output_fields(declarer)

--- a/spec/red_storm/dsl/output_collector_spec.rb
+++ b/spec/red_storm/dsl/output_collector_spec.rb
@@ -10,5 +10,11 @@ describe OutputCollector do
 
     # We should have an alias for #emit_anchor_tuple
     it { should respond_to :emit_anchor_tuple }
+
+    # We should have an alias for #emit_tuple_stream
+    it { should respond_to :emit_tuple_stream }
+
+    # We should have an alias for #emit_anchor_tuple_stream
+    it { should respond_to :emit_anchor_tuple_stream }
   end
 end

--- a/spec/red_storm/dsl/spout_spec.rb
+++ b/spec/red_storm/dsl/spout_spec.rb
@@ -65,21 +65,21 @@ describe RedStorm::SimpleSpout do
         class Spout1 < RedStorm::SimpleSpout
           output_fields :f1
         end
-        Spout1.send(:fields).should == ["f1"]
+        Spout1.send(:fields).should == {"default" => ["f1"]}
       end
 
       it "should parse multiple arguments" do
         class Spout1 < RedStorm::SimpleSpout
           output_fields :f1, :f2
         end
-        Spout1.send(:fields).should == ["f1", "f2"]
+        Spout1.send(:fields).should == {"default" => ["f1", "f2"]}
       end
 
       it "should parse string and symbol arguments" do
         class Spout1 < RedStorm::SimpleSpout
           output_fields :f1, "f2"
         end
-        Spout1.send(:fields).should == ["f1", "f2"]
+        Spout1.send(:fields).should == {"default" => ["f1", "f2"]}
       end
 
       it "should not share state over mutiple classes" do
@@ -89,9 +89,9 @@ describe RedStorm::SimpleSpout do
         class Spout2 < RedStorm::SimpleSpout
           output_fields :f2
         end
-        RedStorm::SimpleSpout.send(:fields).should == []
-        Spout1.send(:fields).should == ["f1"]
-        Spout2.send(:fields).should == ["f2"]
+        RedStorm::SimpleSpout.send(:fields).should == {}
+        Spout1.send(:fields).should == {"default" => ["f1"]}
+        Spout2.send(:fields).should == {"default" => ["f2"]}
       end
     end
 
@@ -787,7 +787,7 @@ describe RedStorm::SimpleSpout do
         spout = Spout1.new
         class RedStorm::Fields; end
         declarer = mock("Declarer")
-        declarer.should_receive(:declare).with("fields")
+        declarer.should_receive(:declareStream).with("default", "fields")
         RedStorm::Fields.should_receive(:new).with(["f1", "f2"]).and_return("fields")
         spout.declare_output_fields(declarer)
       end

--- a/spec/red_storm/dsl/topology_spec.rb
+++ b/spec/red_storm/dsl/topology_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 require 'red_storm/dsl/topology'
 
+require 'pry'
+
 describe RedStorm::SimpleTopology do
 
     # mock Storm imported classes
@@ -112,8 +114,11 @@ describe RedStorm::SimpleTopology do
             output_fields :f3
           end
         end
-        Topology1.spouts.first.output_fields.should == ["f1", "f2"]
-        Topology1.spouts.last.output_fields.should == [ "f3"]
+        # Pry.config.input = STDIN
+        # Pry.config.output = STDOUT
+        # binding.pry
+        Topology1.spouts.first.output_fields.should == { "default" => ["f1", "f2"] }
+        Topology1.spouts.last.output_fields.should == { "default" => ["f3"] }
       end
 
     end
@@ -195,8 +200,8 @@ describe RedStorm::SimpleTopology do
             output_fields :f3
           end
         end
-        Topology1.bolts.first.output_fields.should == ["f1", "f2"]
-        Topology1.bolts.last.output_fields.should == [ "f3"]
+        Topology1.bolts.first.output_fields.should == { "default" => ["f1", "f2"] }
+        Topology1.bolts.last.output_fields.should == { "default" => ["f3"] }
       end
 
     end
@@ -307,8 +312,8 @@ describe RedStorm::SimpleTopology do
 
       RedStorm::TopologyBuilder.should_receive(:new).and_return(builder)
       RedStorm::Configurator.should_receive(:new).and_return(configurator)
-      RedStorm::JRubySpout.should_receive(:new).with("base_path", "SpoutClass1", []).and_return(jruby_spout1)
-      RedStorm::JRubySpout.should_receive(:new).with("base_path", "SpoutClass2", []).and_return(jruby_spout2)
+      RedStorm::JRubySpout.should_receive(:new).with("base_path", "SpoutClass1", {}).and_return(jruby_spout1)
+      RedStorm::JRubySpout.should_receive(:new).with("base_path", "SpoutClass2", {}).and_return(jruby_spout2)
 
       builder.should_receive("setSpout").with('spout_class1', jruby_spout1, 1).and_return(declarer)
       builder.should_receive("setSpout").with('spout_class2', jruby_spout2, 1).and_return(declarer)
@@ -345,8 +350,8 @@ describe RedStorm::SimpleTopology do
 
       RedStorm::TopologyBuilder.should_receive(:new).and_return(builder)
       RedStorm::Configurator.should_receive(:new).and_return(configurator)
-      RedStorm::JRubyBolt.should_receive(:new).with("base_path", "BoltClass1", []).and_return(jruby_bolt1)
-      RedStorm::JRubyBolt.should_receive(:new).with("base_path", "BoltClass2", []).and_return(jruby_bolt2)
+      RedStorm::JRubyBolt.should_receive(:new).with("base_path", "BoltClass1", {}).and_return(jruby_bolt1)
+      RedStorm::JRubyBolt.should_receive(:new).with("base_path", "BoltClass2", {}).and_return(jruby_bolt2)
 
       builder.should_receive("setBolt").with("id1", jruby_bolt1, 2).and_return(declarer)
       builder.should_receive("setBolt").with("id2", jruby_bolt2, 3).and_return(declarer)
@@ -377,8 +382,8 @@ describe RedStorm::SimpleTopology do
         backtype_config = mock(Backtype::Config)
         Backtype::Config.should_receive(:new).any_number_of_times.and_return(backtype_config)
         backtype_config.should_receive(:put)
-        RedStorm::JRubyBolt.should_receive(:new).with("base_path", "BoltClass1", []).and_return(jruby_bolt)
-        RedStorm::JRubySpout.should_receive(:new).with("base_path", "SpoutClass1", []).and_return(jruby_spout)
+        RedStorm::JRubyBolt.should_receive(:new).with("base_path", "BoltClass1", {}).and_return(jruby_bolt)
+        RedStorm::JRubySpout.should_receive(:new).with("base_path", "SpoutClass1", {}).and_return(jruby_spout)
         builder.should_receive("setBolt").with('bolt_class1', jruby_bolt, 1).and_return(@declarer)
         builder.should_receive("setSpout").with('1', jruby_spout, 1).and_return(@declarer)
         @declarer.should_receive("addConfigurations").twice

--- a/spec/red_storm/dsl/topology_spec.rb
+++ b/spec/red_storm/dsl/topology_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'red_storm/dsl/topology'
-
-require 'pry'
+require 'red_storm/dsl/spout'
+require 'red_storm/dsl/bolt'
 
 describe RedStorm::SimpleTopology do
 
@@ -23,10 +23,10 @@ describe RedStorm::SimpleTopology do
     Object.send(:remove_const, "SpoutClass2") if Object.const_defined?("SpoutClass2")
     Object.send(:remove_const, "BoltClass1") if Object.const_defined?("BoltClass1")
     Object.send(:remove_const, "BoltClass2") if Object.const_defined?("BoltClass2")
-    class SpoutClass1; end
-    class SpoutClass2; end
-    class BoltClass1; end
-    class BoltClass2; end
+    class SpoutClass1 < RedStorm::DSL::Spout; end
+    class SpoutClass2 < RedStorm::DSL::Spout; end
+    class BoltClass1 < RedStorm::DSL::Bolt; end
+    class BoltClass2 < RedStorm::DSL::Bolt; end
     SpoutClass1.should_receive(:base_class_path).at_least(0).times.and_return("base_path")
     SpoutClass2.should_receive(:base_class_path).at_least(0).times.and_return("base_path")
     SpoutClass1.should_receive(:java_proxy).at_least(0).times.and_return("RedStorm::JRubySpout")
@@ -114,9 +114,6 @@ describe RedStorm::SimpleTopology do
             output_fields :f3
           end
         end
-        # Pry.config.input = STDIN
-        # Pry.config.output = STDOUT
-        # binding.pry
         Topology1.spouts.first.output_fields.should == { "default" => ["f1", "f2"] }
         Topology1.spouts.last.output_fields.should == { "default" => ["f3"] }
       end

--- a/spec/red_storm/dsl/topology_spec.rb
+++ b/spec/red_storm/dsl/topology_spec.rb
@@ -340,6 +340,7 @@ describe RedStorm::SimpleTopology do
       configurator = mock(RedStorm::Configurator)
       jruby_bolt1 = mock(RedStorm::JRubyBolt)
       jruby_bolt2 = mock(RedStorm::JRubyBolt)
+      jruby_bolt3 = mock(RedStorm::JRubyBolt)
       declarer = mock("Declarer")
 
       RedStorm::TopologyBuilder.should_receive(:new).and_return(builder)
@@ -394,7 +395,20 @@ describe RedStorm::SimpleTopology do
         end
 
         RedStorm::Fields.should_receive(:new).with("f1").and_return("fields")
-        @declarer.should_receive("fieldsGrouping").with('1', "fields")
+        @declarer.should_receive("fieldsGrouping").with('1', 'default', "fields")
+        Topology1.new.start(:cluster)
+      end
+
+      it "should support single string fields with a stream" do
+        class Topology1 < RedStorm::SimpleTopology
+          spout SpoutClass1, :id => 1
+          bolt BoltClass1 do
+            source 1, { :fields => "f1" }, 'custom_stream'
+          end
+        end
+
+        RedStorm::Fields.should_receive(:new).with("f1").and_return("fields")
+        @declarer.should_receive("fieldsGrouping").with('1', 'custom_stream', "fields")
         Topology1.new.start(:cluster)
       end
 
@@ -407,7 +421,20 @@ describe RedStorm::SimpleTopology do
         end
 
         RedStorm::Fields.should_receive(:new).with("s1").and_return("fields")
-        @declarer.should_receive("fieldsGrouping").with('1', "fields")
+        @declarer.should_receive("fieldsGrouping").with('1', 'default', "fields")
+        Topology1.new.start(:cluster)
+      end
+
+      it "should support single symbolic fields with a stream" do
+        class Topology1 < RedStorm::SimpleTopology
+          spout SpoutClass1, :id => 1
+          bolt BoltClass1 do
+            source 1, { :fields => :s1 }, 'custom_stream'
+          end
+        end
+
+        RedStorm::Fields.should_receive(:new).with("s1").and_return("fields")
+        @declarer.should_receive("fieldsGrouping").with('1', 'custom_stream', "fields")
         Topology1.new.start(:cluster)
       end
 
@@ -420,7 +447,20 @@ describe RedStorm::SimpleTopology do
         end
 
         RedStorm::Fields.should_receive(:new).with("f1", "f2").and_return("fields")
-        @declarer.should_receive("fieldsGrouping").with('1', "fields")
+        @declarer.should_receive("fieldsGrouping").with('1', 'default', "fields")
+        Topology1.new.start(:cluster)
+      end
+
+      it "should support string array fields with a stream" do
+        class Topology1 < RedStorm::SimpleTopology
+          spout SpoutClass1, :id => 1
+          bolt BoltClass1 do
+            source 1, { :fields => ["f1", "f2"] }, 'custom_stream'
+          end
+        end
+
+        RedStorm::Fields.should_receive(:new).with("f1", "f2").and_return("fields")
+        @declarer.should_receive("fieldsGrouping").with('1', 'custom_stream', "fields")
         Topology1.new.start(:cluster)
       end
 
@@ -433,7 +473,20 @@ describe RedStorm::SimpleTopology do
         end
 
         RedStorm::Fields.should_receive(:new).with("s1", "s2").and_return("fields")
-        @declarer.should_receive("fieldsGrouping").with('1', "fields")
+        @declarer.should_receive("fieldsGrouping").with('1', 'default', "fields")
+        Topology1.new.start(:cluster)
+      end
+
+      it "should support symbolic array fields with a stream" do
+        class Topology1 < RedStorm::SimpleTopology
+          spout SpoutClass1, :id => 1
+          bolt BoltClass1 do
+            source 1, { :fields => [:s1, :s2] }, 'custom_stream'
+          end
+        end
+
+        RedStorm::Fields.should_receive(:new).with("s1", "s2").and_return("fields")
+        @declarer.should_receive("fieldsGrouping").with('1', 'custom_stream', "fields")
         Topology1.new.start(:cluster)
       end
 
@@ -445,7 +498,19 @@ describe RedStorm::SimpleTopology do
           end
         end
 
-        @declarer.should_receive("shuffleGrouping").with('1')
+        @declarer.should_receive("shuffleGrouping").with('1', 'default')
+        Topology1.new.start(:cluster)
+      end
+
+      it "should support shuffle with a stream" do
+        class Topology1 < RedStorm::SimpleTopology
+          spout SpoutClass1, :id => 1
+          bolt BoltClass1 do
+            source 1, :shuffle, 'custom_stream'
+          end
+        end
+
+        @declarer.should_receive("shuffleGrouping").with('1', 'custom_stream')
         Topology1.new.start(:cluster)
       end
 
@@ -457,7 +522,19 @@ describe RedStorm::SimpleTopology do
           end
         end
 
-        @declarer.should_receive("localOrShuffleGrouping").with('1')
+        @declarer.should_receive("localOrShuffleGrouping").with('1', 'default')
+        Topology1.new.start(:cluster)
+      end
+
+      it "should support local_or_shuffle with a stream" do
+        class Topology1 < RedStorm::SimpleTopology
+          spout SpoutClass1, :id => 1
+          bolt BoltClass1 do
+            source 1, :local_or_shuffle, 'custom_stream'
+          end
+        end
+
+        @declarer.should_receive("localOrShuffleGrouping").with('1', 'custom_stream')
         Topology1.new.start(:cluster)
       end
 
@@ -469,7 +546,19 @@ describe RedStorm::SimpleTopology do
           end
         end
 
-        @declarer.should_receive("noneGrouping").with('1')
+        @declarer.should_receive("noneGrouping").with('1', 'default')
+        Topology1.new.start(:cluster)
+      end
+
+      it "should support none" do
+        class Topology1 < RedStorm::SimpleTopology
+          spout SpoutClass1, :id => 1
+          bolt BoltClass1 do
+            source 1, :none, 'custom_stream'
+          end
+        end
+
+        @declarer.should_receive("noneGrouping").with('1', 'custom_stream')
         Topology1.new.start(:cluster)
       end
 
@@ -481,7 +570,19 @@ describe RedStorm::SimpleTopology do
           end
         end
 
-        @declarer.should_receive("globalGrouping").with('1')
+        @declarer.should_receive("globalGrouping").with('1', 'default')
+        Topology1.new.start(:cluster)
+      end
+
+      it "should support global with a stream" do
+        class Topology1 < RedStorm::SimpleTopology
+          spout SpoutClass1, :id => 1
+          bolt BoltClass1 do
+            source 1, :global, 'custom_stream'
+          end
+        end
+
+        @declarer.should_receive("globalGrouping").with('1', 'custom_stream')
         Topology1.new.start(:cluster)
       end
 
@@ -493,7 +594,19 @@ describe RedStorm::SimpleTopology do
           end
         end
 
-        @declarer.should_receive("allGrouping").with('1')
+        @declarer.should_receive("allGrouping").with('1', 'default')
+        Topology1.new.start(:cluster)
+      end
+
+      it "should support all with a stream" do
+        class Topology1 < RedStorm::SimpleTopology
+          spout SpoutClass1, :id => 1
+          bolt BoltClass1 do
+            source 1, :all, 'custom_stream'
+          end
+        end
+
+        @declarer.should_receive("allGrouping").with('1', 'custom_stream')
         Topology1.new.start(:cluster)
       end
 
@@ -505,7 +618,19 @@ describe RedStorm::SimpleTopology do
           end
         end
 
-        @declarer.should_receive("directGrouping").with('1')
+        @declarer.should_receive("directGrouping").with('1', 'default')
+        Topology1.new.start(:cluster)
+      end
+
+      it "should support direct with a stream" do
+        class Topology1 < RedStorm::SimpleTopology
+          spout SpoutClass1, :id => 1
+          bolt BoltClass1 do
+            source 1, :direct, 'custom_stream'
+          end
+        end
+
+        @declarer.should_receive("directGrouping").with('1', 'custom_stream')
         Topology1.new.start(:cluster)
       end
     end
@@ -563,7 +688,7 @@ describe RedStorm::SimpleTopology do
 
       Topology1.spouts.first.id.should == '1'
       Topology1.bolts.first.id.should == '2'
-      Topology1.bolts.first.sources.first.should == ['1', {:shuffle => nil}]
+      Topology1.bolts.first.sources.first.should == ['1', {:shuffle => nil}, 'default']
     end
 
     it "should support explicit string ids" do
@@ -577,7 +702,7 @@ describe RedStorm::SimpleTopology do
 
       Topology1.spouts.first.id.should == "id1"
       Topology1.bolts.first.id.should == "id2"
-      Topology1.bolts.first.sources.first.should == ["id1", {:shuffle => nil}]
+      Topology1.bolts.first.sources.first.should == ["id1", {:shuffle => nil}, 'default']
     end
 
     it "should support implicit string ids" do
@@ -591,7 +716,7 @@ describe RedStorm::SimpleTopology do
 
       Topology1.spouts.first.id.should == "spout_class1"
       Topology1.bolts.first.id.should == "bolt_class1"
-      Topology1.bolts.first.sources.first.should == ["spout_class1", {:shuffle => nil}]
+      Topology1.bolts.first.sources.first.should == ["spout_class1", {:shuffle => nil}, 'default']
     end
 
     it "should support implicit symbol ids" do
@@ -605,7 +730,7 @@ describe RedStorm::SimpleTopology do
 
       Topology1.spouts.first.id.should == "spout_class1"
       Topology1.bolts.first.id.should == "bolt_class1"
-      Topology1.bolts.first.sources.first.should == ['spout_class1', {:shuffle => nil}]
+      Topology1.bolts.first.sources.first.should == ['spout_class1', {:shuffle => nil}, 'default']
     end
 
     it "should support implicit class ids" do
@@ -619,7 +744,7 @@ describe RedStorm::SimpleTopology do
 
       Topology1.spouts.first.id.should == "spout_class1"
       Topology1.bolts.first.id.should == "bolt_class1"
-      Topology1.bolts.first.sources.first.should == ["spout_class1", {:shuffle => nil}]
+      Topology1.bolts.first.sources.first.should == ["spout_class1", {:shuffle => nil}, 'default']
     end
 
     it "should raise on unresolvable" do
@@ -633,7 +758,7 @@ describe RedStorm::SimpleTopology do
 
       Topology1.spouts.first.id.should == "spout_class1"
       Topology1.bolts.first.id.should == "bolt_class1"
-      Topology1.bolts.first.sources.first.should == ["dummy", {:shuffle => nil}]
+      Topology1.bolts.first.sources.first.should == ["dummy", {:shuffle => nil}, 'default']
 
       lambda {Topology1.resolve_ids!(Topology1.spouts + Topology1.bolts)}.should raise_error RuntimeError, "cannot resolve BoltClass1 source id=dummy"
     end

--- a/spec/red_storm/dsl/topology_spec.rb
+++ b/spec/red_storm/dsl/topology_spec.rb
@@ -118,6 +118,28 @@ describe RedStorm::SimpleTopology do
         Topology1.spouts.last.output_fields.should == { "default" => ["f3"] }
       end
 
+      it "should default output_fields to the class defined fields" do
+        class SpoutClass1
+          output_fields :f1, :f2
+        end
+        class Topology1 < RedStorm::SimpleTopology
+          spout SpoutClass1
+        end
+        Topology1.spouts.first.output_fields.should == { "default" => ["f1", "f2"] }
+      end
+
+      it "should override class defined fields with topology output fields" do
+        class SpoutClass1
+          output_fields :f1, :f2
+        end
+        class Topology1 < RedStorm::SimpleTopology
+          spout SpoutClass1 do
+            output_fields :f3, :f4
+          end
+        end
+        Topology1.spouts.first.output_fields.should == { "default" => ["f3", "f4"] }
+      end
+
     end
 
     describe "bolt statement" do
@@ -199,6 +221,29 @@ describe RedStorm::SimpleTopology do
         end
         Topology1.bolts.first.output_fields.should == { "default" => ["f1", "f2"] }
         Topology1.bolts.last.output_fields.should == { "default" => ["f3"] }
+      end
+
+      it "should default output_fields to the class defined fields" do
+        class BoltClass1
+          output_fields :f1, :f2
+        end
+        class Topology1 < RedStorm::SimpleTopology
+          bolt BoltClass1 do
+          end
+        end
+        Topology1.bolts.first.output_fields.should == { "default" => ["f1", "f2"] }
+      end
+
+      it "should override class defined fields with topology output fields" do
+        class BoltClass1
+          output_fields :f1, :f2
+        end
+        class Topology1 < RedStorm::SimpleTopology
+          bolt BoltClass1 do
+            output_fields :f3, :f4
+          end
+        end
+        Topology1.bolts.first.output_fields.should == { "default" => ["f3", "f4"] }
       end
 
     end


### PR DESCRIPTION
This is an initial attempt at adding support for declaring named streams and emitting messages on streams for bolts. The intent of this feature is to make it easier to build storm topologies where bolts can control where they emit messages to by directing flow using streams and enabling other bolts to subscribe to a source with those declared streams. These modifications _should not_ introduce any breaking changes to the RedStorm API and enable existing users to upgrade without having to rewrite their bolts or topologies. 

I am submitting this as in initial draft implementation and hoping to receive comments or open a discussion about what the API should look like to enable this type of support to the user. 

Declaring a new stream occurs with the call to `output_fields` within the bolt implementation. Instead of an array of field names, streams are declared using a hash where the key is the name of the stream and the value is a single field or array of fields.

``` ruby
class Bolt2 < RedStorm::DSL::Bolt
  output_fields :custom_stream => :f1

  on_receive :stream => :custom_stream do |tuple|
    tuple
  end
end
```

In this example, a new stream is declared called `custom_stream` with a single output field. The `on_receive` method defines the default stream that it will emit to, since auto emit is enabled. For more granular control, a Bolt that defines multiple streams can emit values using the `emit_tuple_stream` method of the `OutputCollector`, which is called from the `(un)anchored_stream_emit' helper method of the bolt. 

``` ruby
class Bolt1 < RedStorm::DSL::Bolt
  output_fields :f1, :another_stream => :f2

  on_receive :emit => false  do |tuple|
    if something
      unanchored_stream_emit 'custom_stream', tuple
    else
      unanchored_emit tuple
    end
  end
end
```

Once a bolt defines what streams it will emit messages on, other bolts can subscribe to those streams when they are configured in their topology. I added a third parameter to the `source` method which allows the bolt to provide the name of the stream it wants to receive messages from. This introduces a small API change because if the user original provided a `Hash` for the grouping, then that hash will need to be wrapped in curly braces to avoid a syntax error with the Ruby parser.

``` ruby
class Topology1 < RedStorm::DSL::Topology
  spout SomeSpout

  bolt Bolt1 do
    source SomeSpout, :fields => ["f1"]
  end

  bolt Bolt2 do 
    source Bolt1, { :fields => ["f1"] }, "custom_stream"
  end

  ...
end
```
## What's not implemented (yet)

Currently only bolts can declare streams. I still need to add support for Spouts. Which means that bolts can only subscribe to other bolt streams. 

Also, you cannot declare streams and fields for bolts within the bolt definition of a topology. The `output_fields` that get declared in the definition block of the topology are passed the the constructor of the `JRubyShellBolt` class which currently accepts an array of `String`s for the `fields` parameter. I wasn't sure what the best path was to add stream support here. I thought an overloaded constructor which expects a `HashMap` instead of an array might work, but that would prevent users from declaring custom streams and fields for the default stream, like this:

``` ruby
output_fields :f1, :f2, :my_stream => [:f3, :f4]
```

I think a decision needs to be made about how this should impact the API. Restricting the `fields` parameter of that Java class to use a map would then result in:

``` ruby
output_fields :default => [:f1, :f2], :my_stream => [:f3, :f4]
```

...where the `default` stream needs to be explicitly declared if the user wants to use it. Alternatively, the `BoltDefinition` code in Ruby could be smart enough to parse out this data structure and invoke the appropriate constructor and pass in the default fields if provided through a setter on the Java class. 

Anyways, I am looking for lots of feedback and an open discussion about what direction makes the most sense for adding in this type of feature. Any and all comments are welcome and I'm happy to make any changes necessary to help get this accepted and into the RedStorm baseline. 
