### PR TITLE
Use HTTPS instead of HTTP - repo.maven.apache.org

### DIFF
--- a/ivy/settings.xml
+++ b/ivy/settings.xml
@@ -4,7 +4,7 @@
   <resolvers>
     <chain name="repositories">
       <ibiblio name="ibiblio" m2compatible="true"/>
-      <ibiblio name="sonatype" root="http://repo.maven.apache.org/maven2/" m2compatible="true"/>
+      <ibiblio name="sonatype" root="https://repo.maven.apache.org/maven2/" m2compatible="true"/>
       <ibiblio name="clojars" root="http://clojars.org/repo/" m2compatible="true"/>
       <ibiblio name="conjars" root="http://conjars.org/repo/" m2compatible="true"/>
     </chain>


### PR DESCRIPTION
501 HTTPS Required. 
Use https://repo.maven.apache.org/maven2/
More information at https://links.sonatype.com/central/501-https-required